### PR TITLE
Update MicroKnight font copyright to Niels Krogh Mortensen

### DIFF
--- a/README
+++ b/README
@@ -534,7 +534,7 @@
       P0T-NOoDLE is © Leo "Nudel" Davidson
       ttf, fon, eot, raw & psf v1/v2 versions are © dMG/t!s^dS!
 
-      MicroKnight is © Unknown author
+      MicroKnight is © Niels Krogh Mortensen
       ttf, fon, eot, raw & psf v1/v2 versions of MicroKnight are © dMG/t!s^dS!
       ttf, fon, eot, raw & psf v1/v2 versions of MicroKnightPlus are
       © dMG/t!s^dS!


### PR DESCRIPTION
Please update MicroKnight font copyright to Niels Krogh Mortensen

MicroKnight font was created by my friend Niels Krogh Mortensen

Documentation/Reference:

Quoting (http://www.pouet.net/topic.php?which=9097)

`Question: Who was the author of the Microknight font?`

`Reply: The MicroKnight font was designed by Niels Krogh Mortensen also known as Nölb / Grafictive... his website is: www.animation.dk`